### PR TITLE
fixing CamelCase on service method definition

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -35,7 +35,7 @@ message Greeting {
 }
 
 service Greeter {
-  rpc sayHello (Person) returns (Greeting) { }
+  rpc SayHello (Person) returns (Greeting) { }
 }
 ```
 


### PR DESCRIPTION
The documentation quick start shows the proto file with the wrong style (wrong CamelCase) on the method definition. This causes the proxy to fail because the methods are not found on the proto files.

Docs now follow the style defined in https://developers.google.com/protocol-buffers/docs/style 

Thanks
-Ivan